### PR TITLE
feat: GitHub update checker admin notice (v2.9)

### DIFF
--- a/facebook-request-throttle.php
+++ b/facebook-request-throttle.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Facebook Request Throttle
  * Description: Limits the request frequency from Facebook's web crawler and other configurable user agents.
- * Version:     2.6
+ * Version:     2.9
  * Author:      Nadim Tuhin
  * Author URI:  https://nadimtuhin.com
  * License:     MIT
@@ -12,6 +12,10 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( "We're sorry, but you can not directly access this file." );
+}
+
+if ( ! defined( 'NT_PLUGIN_VERSION' ) ) {
+	define( 'NT_PLUGIN_VERSION', '2.9' );
 }
 
 // Fallback constant — define this in wp-config.php to override the dashboard setting.
@@ -439,3 +443,71 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 	WP_CLI::add_command( 'fb-throttle', 'NT_Facebook_Throttle_CLI' );
 }
+
+// ── GitHub Update Checker ──────────────────────────────────────────────────────
+
+/**
+ * Check GitHub releases for a newer version of this plugin.
+ *
+ * Caches the result for 12 hours via a WP transient to avoid hammering the API.
+ *
+ * @return string|false Latest version tag (e.g. "2.9") or false on failure.
+ */
+function nt_check_github_for_update() {
+	$cached = get_transient( 'nt_github_latest_version' );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	$response = wp_remote_get(
+		'https://api.github.com/repos/nadimtuhin/Facebook-Request-Throttle-WordPress-Plugin/releases/latest',
+		array(
+			'timeout'    => 5,
+			'user-agent' => 'Facebook-Request-Throttle-WP-Plugin/' . NT_PLUGIN_VERSION,
+		)
+	);
+
+	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return false;
+	}
+
+	$body = json_decode( wp_remote_retrieve_body( $response ), true );
+	if ( empty( $body['tag_name'] ) ) {
+		return false;
+	}
+
+	// Strip leading "v" so "v2.9" → "2.9" for version_compare().
+	$latest = ltrim( $body['tag_name'], 'v' );
+	set_transient( 'nt_github_latest_version', $latest, 12 * HOUR_IN_SECONDS );
+	return $latest;
+}
+
+/**
+ * Show an admin notice when a newer GitHub release exists.
+ */
+function nt_maybe_show_update_notice() {
+	if ( ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
+
+	$latest = nt_check_github_for_update();
+	if ( false === $latest ) {
+		return;
+	}
+
+	if ( ! version_compare( $latest, NT_PLUGIN_VERSION, '>' ) ) {
+		return;
+	}
+
+	$url = 'https://github.com/nadimtuhin/Facebook-Request-Throttle-WordPress-Plugin/releases/latest';
+	printf(
+		'<div class="notice notice-warning"><p><strong>%s</strong> %s <a href="%s" target="_blank" rel="noopener noreferrer">%s &rarr;</a></p></div>',
+		esc_html__( 'Facebook Request Throttle:', 'facebook-request-throttle' ),
+		/* translators: %s: new version number */
+		sprintf( esc_html__( 'Version %s is available on GitHub.', 'facebook-request-throttle' ), esc_html( $latest ) ),
+		esc_url( $url ),
+		esc_html__( 'Download update', 'facebook-request-throttle' )
+	);
+}
+add_action( 'admin_notices', 'nt_maybe_show_update_notice' );
+

--- a/tests/ThrottleTest.php
+++ b/tests/ThrottleTest.php
@@ -314,4 +314,101 @@ class ThrottleTest extends TestCase
         $log = get_option('nt_facebook_throttle_log', []);
         $this->assertCount(100, $log);
     }
+
+    // ── Update checker ────────────────────────────────────────────────────────
+
+    private function setHttpResponse(int $code, string $body): void
+    {
+        $GLOBALS['_nt_http_response'] = [
+            'response' => ['code' => $code],
+            'body'     => $body,
+        ];
+    }
+
+    /** @test */
+    public function test_update_checker_returns_latest_version_from_github(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $this->setHttpResponse(200, json_encode(['tag_name' => 'v9.9.9']));
+
+        $result = nt_check_github_for_update();
+
+        $this->assertSame('9.9.9', $result);
+    }
+
+    /** @test */
+    public function test_update_checker_strips_leading_v(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $this->setHttpResponse(200, json_encode(['tag_name' => 'v2.9']));
+
+        $this->assertSame('2.9', nt_check_github_for_update());
+    }
+
+    /** @test */
+    public function test_update_checker_returns_false_on_http_error(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $GLOBALS['_nt_http_response'] = new WP_Error('http_request_failed', 'timeout');
+
+        $this->assertFalse(nt_check_github_for_update());
+    }
+
+    /** @test */
+    public function test_update_checker_returns_false_on_non_200(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $this->setHttpResponse(403, '{"message":"rate limited"}');
+
+        $this->assertFalse(nt_check_github_for_update());
+    }
+
+    /** @test */
+    public function test_update_checker_returns_false_on_missing_tag(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $this->setHttpResponse(200, json_encode(['foo' => 'bar']));
+
+        $this->assertFalse(nt_check_github_for_update());
+    }
+
+    /** @test */
+    public function test_update_checker_uses_cached_transient(): void
+    {
+        set_transient('nt_github_latest_version', '3.0.0', 3600);
+        // HTTP stub would return something different — transient wins.
+        $this->setHttpResponse(200, json_encode(['tag_name' => 'v9.0']));
+
+        $this->assertSame('3.0.0', nt_check_github_for_update());
+        delete_transient('nt_github_latest_version');
+    }
+
+    /** @test */
+    public function test_update_notice_not_shown_when_up_to_date(): void
+    {
+        delete_transient('nt_github_latest_version');
+        // Return same version as plugin — no update available.
+        $this->setHttpResponse(200, json_encode(['tag_name' => 'v' . NT_PLUGIN_VERSION]));
+
+        ob_start();
+        nt_maybe_show_update_notice();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    /** @test */
+    public function test_update_notice_shown_when_newer_version_exists(): void
+    {
+        delete_transient('nt_github_latest_version');
+        $this->setHttpResponse(200, json_encode(['tag_name' => 'v9.9.9']));
+
+        ob_start();
+        nt_maybe_show_update_notice();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('9.9.9', $output);
+        $this->assertStringContainsString('notice-warning', $output);
+        $this->assertStringContainsString('releases/latest', $output);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,12 @@ function set_transient(string $k, mixed $v, int $ttl): bool
     return true;
 }
 
+function delete_transient(string $k): bool
+{
+    unset($GLOBALS['_nt_transients'][$k]);
+    return true;
+}
+
 function get_option(string $k, mixed $default = []): mixed
 {
     return $GLOBALS['_nt_options'][$k] ?? $default;
@@ -87,5 +93,35 @@ function wp_die(string $msg, string $title, array $args): never
 
 // Load plugin (constants guard against double-define)
 define('ABSPATH', true);
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+
+// HTTP stubs — tests override $GLOBALS['_nt_http_response'] to control the response.
+function wp_remote_get(string $url, array $args = []): array|WP_Error
+{
+    return $GLOBALS['_nt_http_response'] ?? new WP_Error('http_request_failed', 'No stub set');
+}
+function wp_remote_retrieve_response_code(array|WP_Error $r): int
+{
+    return is_array($r) ? ($r['response']['code'] ?? 0) : 0;
+}
+function wp_remote_retrieve_body(array|WP_Error $r): string
+{
+    return is_array($r) ? ($r['body'] ?? '') : '';
+}
+function is_wp_error(mixed $v): bool
+{
+    return $v instanceof WP_Error;
+}
+
+class WP_Error
+{
+    public function __construct(public string $code = '', public string $message = '') {}
+}
+
+function esc_url(string $url): string { return htmlspecialchars($url, ENT_QUOTES); }
+function wp_kses_post(string $s): string { return $s; }
 
 require_once __DIR__ . '/../facebook-request-throttle.php';


### PR DESCRIPTION
## What

Shows a WP admin notice when a newer version is available on GitHub.

## How it works

1. On `admin_notices`, calls `nt_check_github_for_update()`
2. That hits `api.github.com/repos/.../releases/latest` (5s timeout)
3. Result cached in a WP transient for **12 hours** — no repeated API calls
4. If latest tag > current `NT_PLUGIN_VERSION`, shows a `notice-warning` with a direct link to the release

## Notice is NOT shown when
- User lacks `update_plugins` capability
- GitHub API returns an error or rate-limits
- Plugin is already up to date

## Tests
8 new tests covering: version parse, v-prefix strip, HTTP error, 403, missing tag, transient cache, notice hidden when current, notice shown when outdated.

44/44 passing, PHPCS 0 errors.